### PR TITLE
[#284] Dash stable

### DIFF
--- a/docker/dash/backend/Dockerfile
+++ b/docker/dash/backend/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER Akvo Foundation <devops@akvo.org>
 WORKDIR /usr/src/app
 RUN git clone https://github.com/akvo/akvo-dash.git && \
     cd akvo-dash/backend && \
+    git checkout master && \
     lein deps && \
     mv "$(lein uberjar | sed -n 's/^Created \(.*standalone\.jar\)/\1/p')" ../../app-standalone.jar && \
     rm -rf /usr/src/app/.m2

--- a/docker/dash/backend/Dockerfile
+++ b/docker/dash/backend/Dockerfile
@@ -7,6 +7,6 @@ RUN git clone https://github.com/akvo/akvo-dash.git && \
     git checkout master && \
     lein deps && \
     mv "$(lein uberjar | sed -n 's/^Created \(.*standalone\.jar\)/\1/p')" ../../app-standalone.jar && \
-    rm -rf /usr/src/app/.m2
+    rm -rf ~/.m2
 
 CMD ["java", "-jar", "app-standalone.jar"]


### PR DESCRIPTION
- This make sure we checkout stable (master), then we can keep the deployment for demos.
- This fix a path error when removing the .m2 repo.