### PR TITLE
Commented relevant hostname redirects in akvosites nginx template

### DIFF
--- a/puppet/modules/akvosites/templates/akvosites-nginx.conf.erb
+++ b/puppet/modules/akvosites/templates/akvosites-nginx.conf.erb
@@ -3,6 +3,7 @@
 server {
     listen 80;
     server_name
+        # Hostname redirects only exist in production!
         <% if @redirected_hostnames_washalliance %>
             <% @redirected_hostnames_washalliance.each do |site_hostname| %>
         <% end %>
@@ -72,6 +73,7 @@ server {
 server {
     listen 80;
     server_name
+        # Hostname redirects only exist in production!
         <% if @redirecited_hostnames_walkingforwater %>
             <% @redirected_hostnames_walkingforwater.each do |site_hostname| %>
         <% end %>


### PR DESCRIPTION
The `redirected_hostnames_` arrays are only intended for production configs.

Therefore, we have wrapped them in conditional logic to ignore them in other environments where they do not exist.