### PR TITLE
[Fixes #79] Disallow indexing test server content

### DIFF
--- a/puppet/modules/rsr/templates/nginx-extra-server.conf.erb
+++ b/puppet/modules/rsr/templates/nginx-extra-server.conf.erb
@@ -8,6 +8,10 @@
     client_max_body_size 150m; # temporary fix for https://github.com/akvo/akvo-provisioning/issues/277
     # client_max_body_size 8m;
 
+    <% if @rsr_debug %>
+    add_header  X-Robots-Tag "noindex, nofollow, nosnippet, noarchive";
+    <% end %>
+
     # redirects following the RSR v3 release:
     # see https://github.com/akvo/akvo-provisioning/issues/137
     # rewrite ^/(en|de|nl|es|fr|ru)/(.*)$ /$2 redirect;


### PR DESCRIPTION
This was partially fixed in akvo/akvo-rsr#2064 using a meta tag in the
HTML template.  But, that fix didn't work for other content like PDFs.

This commit adds an X-Robots-Tag header and stops any further indexing,
and also removes already indexed content in the next crawl.  Adding a
robots.txt would only stop future crawling, but would only indirectly
effect the indexing.
https://developers.google.com/webmasters/control-crawl-index/docs/faq#h17

Fixes akvo/akvo-rsr#2232 